### PR TITLE
🩹 fix: 프로젝트 post를 작성한 user nickname을 DEV_POSTS 테이블에 함께 insert 하도록 수정

### DIFF
--- a/src/context/PostContextProvider.jsx
+++ b/src/context/PostContextProvider.jsx
@@ -38,7 +38,8 @@ const PostContextProvider = ({ children }) => {
         project_end_date,
         tech_stack,
         thumbnail_url,
-        author_id: user.id
+        author_id: user.id,
+        author_nickname: user.nickname
       })
       .select();
 


### PR DESCRIPTION
## What is this PR? 🔍
- postContextProvider.jsx: supabase에 post 정보 insert시 현재 세션의 유저 정보에서 nickname을 함께 전송하도록 수정했습니다

## Screenshot 📸
![image](https://github.com/user-attachments/assets/821d0c26-14a5-4868-9114-e2e1ff21e6d6)
- supabase DEV_POSTS 테이블에 입력 됩니다

## Test Checklist ☑️
- 글 작성시 테이블에 닉네임 등록 확인 완료

## Others 👻
- Card에 닉네임 정보가 필요해서 우선 merge 해두겠습니다!