### PR TITLE
♻️ refactor: 수정한 내용만 supabase에 update하도록 변경

### DIFF
--- a/src/components/common/ImageInput.jsx
+++ b/src/components/common/ImageInput.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
-const ImageInput = ({ label, value, setValue, prevThumbnailUrl, ...props }) => {
+const ImageInput = ({ label, value, setValue, prevThumbnailUrl, setPrevThumbnail, ...props }) => {
   const inputRef = useRef(null);
 
   const handleButtonClick = () => {
@@ -48,9 +48,10 @@ const ImageInput = ({ label, value, setValue, prevThumbnailUrl, ...props }) => {
     (async () => {
       const prevThumbnailFile = await urlToFile(prevThumbnailUrl);
 
-      if (isMounted) {
+      if (isMounted && prevThumbnailFile) {
         setValue(prevThumbnailFile);
         createPreviewUrl(prevThumbnailFile);
+        setPrevThumbnail(prevThumbnailFile);
       }
     })();
 

--- a/src/components/posting/PostingForm.jsx
+++ b/src/components/posting/PostingForm.jsx
@@ -2,7 +2,7 @@ import ImageInput from '../common/ImageInput.jsx';
 import styled from 'styled-components';
 import Button from '../common/Button.jsx';
 
-const PostingForm = ({ type, postContents, setPostContents, handleSubmit, prevThumbnailUrl }) => {
+const PostingForm = ({ type, postContents, setPostContents, handleSubmit, prevThumbnailUrl, setPrevThumbnail }) => {
   const { title, content, project_start_date, project_end_date, tech_stack, thumbnail } = postContents;
   const setThumbnail = (file) => {
     setPostContents({ ...postContents, thumbnail: file });
@@ -21,6 +21,7 @@ const PostingForm = ({ type, postContents, setPostContents, handleSubmit, prevTh
           value={thumbnail}
           setValue={setThumbnail}
           prevThumbnailUrl={prevThumbnailUrl}
+          setPrevThumbnail={setPrevThumbnail}
         />
       </S_InputFieldContainer>
       <S_InputFieldContainer>

--- a/src/context/PostContextProvider.jsx
+++ b/src/context/PostContextProvider.jsx
@@ -54,27 +54,22 @@ const PostContextProvider = ({ children }) => {
 
   const getPostContents = (id) => posts.find((post) => post.post_id === id);
 
-  const editPost = async ({ id, title, content, project_start_date, project_end_date, tech_stack, thumbnail }) => {
-    tech_stack = tech_stack.split(' ');
+  const editPost = async (id, prevColumns, newColumns) => {
+    const updateColumns = {};
 
-    // thumbnail type 확인해서 file이면 getImageURL 아니면 그대로 insert하기
-    const thumbnail_url = await getImageURL(thumbnail, 'thumbnails');
+    if (prevColumns.title !== newColumns.title) updateColumns.title = newColumns.title;
+    if (prevColumns.tech_stack !== newColumns.tech_stack) updateColumns.tech_stack = newColumns.tech_stack.split(' ');
+    if (prevColumns.content !== newColumns.content) updateColumns.content = newColumns.content;
+    if (prevColumns.project_start_date !== newColumns.project_start_date)
+      updateColumns.project_start_date = newColumns.project_start_date;
+    if (prevColumns.project_end_date !== newColumns.project_end_date)
+      updateColumns.project_end_date = newColumns.project_end_date;
+    if (prevColumns.thumbnail !== newColumns.thumbnail)
+      updateColumns.thumbnail_url = await getImageURL(newColumns.thumbnail, 'thumbnails');
 
     // TODO: 민영 - 유효성검사 추가
 
-    const { error: tableError } = await supabase
-      .from('DEV_POSTS')
-      .update({
-        title,
-        content,
-        project_start_date,
-        project_end_date,
-        tech_stack,
-        thumbnail_url,
-        author_id: user.id
-      })
-      .eq('post_id', id)
-      .select();
+    const { error: tableError } = await supabase.from('DEV_POSTS').update(updateColumns).eq('post_id', id).select();
 
     if (tableError) {
       console.log('🚀 ~ addPosts ~ tableError:', tableError);

--- a/src/pages/EditPost.jsx
+++ b/src/pages/EditPost.jsx
@@ -6,28 +6,23 @@ import PostingForm from '../components/posting/PostingForm.jsx';
 const EditPost = () => {
   const { id } = useParams();
   const { getPostContents, editPost } = useContext(PostContext);
-  const {
-    content: prevContent,
-    project_end_date: prevProjectEndDate,
-    project_start_date: prevProjectStartDate,
-    tech_stack: prevTechStack,
-    thumbnail_url: prevThumbnailUrl,
-    title: prevTitle
-  } = getPostContents(+id);
+  const prevContents = getPostContents(+id);
+  const setPrevThumbnail = (file) => {
+    prevContents.thumbnail = file;
+  };
 
   const [newPostContents, setNewPostContents] = useState({
-    id: +id,
-    title: prevTitle,
-    content: prevContent,
-    project_start_date: prevProjectStartDate,
-    project_end_date: prevProjectEndDate,
-    tech_stack: prevTechStack.join(' '),
+    title: prevContents.title,
+    content: prevContents.content,
+    project_start_date: prevContents.project_start_date,
+    project_end_date: prevContents.project_end_date,
+    tech_stack: prevContents.tech_stack.join(' '),
     thumbnail: null
   });
 
   const navigate = useNavigate();
   const handleEditPost = async () => {
-    await editPost(newPostContents);
+    await editPost(+id, prevContents, newPostContents);
     navigate(`/detailpost/${id}`, { replace: true });
   };
 
@@ -37,7 +32,8 @@ const EditPost = () => {
       postContents={newPostContents}
       setPostContents={setNewPostContents}
       handleSubmit={handleEditPost}
-      prevThumbnailUrl={prevThumbnailUrl}
+      prevThumbnailUrl={prevContents.thumbnail_url}
+      setPrevThumbnail={setPrevThumbnail}
     />
   );
 };


### PR DESCRIPTION
## What is this PR? 🔍
- ImageInput.jsx: 기존 썸네일이 있을 때만 previewURL을 설정하도록 수정
- PostContextProvider.jsx: supabase 업데이트시 기존 값과 비교하여 변경된 column만 수정할 데이터에 포함되도록 변경
- EditPost.jsx: editPost() 호출시 post_id, 기존내용, 변경된 내용 전달하도록 수정

## Screenshot 📸
![스크린샷 2024-09-02 오후 6 57 41](https://github.com/user-attachments/assets/c743d287-e61c-477a-9cf7-e32cb69d527a)

![Sep-02-2024 19-01-57](https://github.com/user-attachments/assets/79ad206c-4443-481d-9716-1bc15f531681)

![스크린샷 2024-09-02 오후 7 00 35](https://github.com/user-attachments/assets/33bbc188-3e21-4851-8812-2dbba5b6d00f)

- 다른 column에 영향 없이 변경한 부분만 수정됨
- 기존에 썸네일을 수정하지 않아도 새로운 이미지로 인지하여 storage에 저장 -> 새로운 url을 받아왔는데, 이 부분도 마찬가지로 해결

## Test Checklist ☑️
- [x] 썸네일 외 다른 내용을 수정했을 때 스토리지 추가, 새로운 url 생성되지 않는 것 확인
- [x] 기존 썸네일이 있는 상태에서 다른 썸네일로 수정/삭제 확인
- [x] 기존 썸네일이 없는 상태에서 다른 썸네일로 수정/삭제 확인

## Others 👻
기타 내용 없습니다~