### PR TITLE
Fix/profile update image: 프로필이미지 관련 

### DIFF
--- a/src/context/PostContextProvider.jsx
+++ b/src/context/PostContextProvider.jsx
@@ -65,8 +65,6 @@ const PostContextProvider = ({ children }) => {
     if (prevColumns.thumbnail !== newColumns.thumbnail)
       updateColumns.thumbnail_url = await getImageURL(newColumns.thumbnail, 'thumbnails');
 
-    // TODO: 민영 - 유효성검사 추가
-
     const { error: tableError } = await supabase.from('DEV_POSTS').update(updateColumns).eq('post_id', id).select();
 
     if (tableError) {

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -25,29 +25,38 @@ const MyPage = () => {
 
   const [isEditMode, setIsEditMode] = useState(false);
 
-  let prevAvatar = null;
-  const setPrevAvatar = (file) => {
-    prevAvatar = file;
-    setFormData({ ...formData, avatar_url: file });
-  };
+  const [prevAvatar, setPrevAvatar] = useState(null);
 
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
-  let avatarUrl;
   const handleImageChange = async (file) => {
-    if (file && prevAvatar !== file) {
-      avatarUrl = await getImageURL(file, 'avatars', `public/${user.id}`);
-      setFormData({ ...formData, avatar_url: avatarUrl });
-    }
+     setFormData({...formData, avatar_url: file})
   };
+
+  const handleEnterEditMode = () => {
+    setIsEditMode(true);
+  }
 
   const handleSubmit = async (e) => {
     e.preventDefault();
 
+    let updateObj = {
+      name: formData.name,
+      nickname: formData.nickname,
+    }
+
+    if (prevAvatar !== formData.avatar_url) {
+      const url = await getImageURL(formData.avatar_url, 'avatars', `public/${user.id}`);
+      updateObj = { ...formData, avatar_url: url };
+      console.log("이미지 변동: ", prevAvatar, "=> ", formData.avatar_url)
+    } else {
+      console.log('이미지 변동 없음');
+    }
+
     try {
-      const { error } = await supabase.from('profile').update(formData).eq('id', user.id);
+      const { error } = await supabase.from('profile').update(updateObj).eq('id', user.id);
 
       if (error) {
         console.error('정보 수정 오류:', error);
@@ -104,7 +113,7 @@ const MyPage = () => {
               label="프로필 이미지 선택"
               value={formData.avatar_url}
               setValue={handleImageChange}
-              prevThumbnailUrl={formData.avatar_url}
+              prevThumbnailUrl={user.avatar_url}
               setPrevThumbnail={setPrevAvatar}
             />
             <S_MyPageButton type="button" onClick={handleSubmit}>
@@ -123,7 +132,7 @@ const MyPage = () => {
               <S_ProfileTitle>프로필 이미지:</S_ProfileTitle>
               <S_ProfileImage src={formData.avatar_url} alt="프로필 이미지" />
             </S_ProfileItem>
-            <S_MyPageButton type="button" onClick={() => setIsEditMode(true)}>
+            <S_MyPageButton type="button" onClick={handleEnterEditMode}>
               정보 수정
             </S_MyPageButton>
           </>

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -63,7 +63,7 @@ const MyPage = () => {
         return;
       }
 
-      setUser({ ...user, ...formData });
+      setUser({ ...user, ...updateObj });
       setIsEditMode(false);
       alert('회원정보가 성공적으로 수정되었습니다.');
     } catch (error) {

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -130,7 +130,7 @@ const MyPage = () => {
             </S_ProfileItem>
             <S_ProfileItem>
               <S_ProfileTitle>프로필 이미지:</S_ProfileTitle>
-              <S_ProfileImage src={formData.avatar_url} alt="프로필 이미지" />
+              <S_ProfileImage src={user.avatar_url} alt="프로필 이미지" />
             </S_ProfileItem>
             <S_MyPageButton type="button" onClick={handleEnterEditMode}>
               정보 수정

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -47,12 +47,13 @@ const MyPage = () => {
     e.preventDefault();
 
     try {
-      console.log('updateObj', formData);
       const { error } = await supabase.from('profile').update(formData).eq('id', user.id);
+
       if (error) {
         console.error('정보 수정 오류:', error);
         return;
       }
+
       setUser({ ...user, ...formData });
       setIsEditMode(false);
       alert('회원정보가 성공적으로 수정되었습니다.');
@@ -60,9 +61,10 @@ const MyPage = () => {
       console.error('정보 수정 오류:', error);
     }
   };
-  //----------------------------------
+
   const { posts } = useContext(PostContext);
   const userPosts = posts.filter((post) => post.author_id === user.id);
+
   const septemPost = userPosts.filter((post) => {
     const end_date = post.project_end_date;
     const dateArr = end_date.split('-');
@@ -76,12 +78,14 @@ const MyPage = () => {
     const endMonth = dateArr[1];
     return endMonth === '08';
   });
+
   const julyPosts = userPosts.filter((post) => {
     const end_date = post.project_end_date;
     const dateArr = end_date.split('-');
     const endMonth = dateArr[1];
     return endMonth === '07';
   });
+
   return (
     <S_MyPageLayout>
       <S_MyPageContainer>
@@ -159,6 +163,7 @@ const S_MyPageLayout = styled.div`
   flex-direction: column;
   min-height: 100vh;
 `;
+
 const S_MyPageContainer = styled.div`
   max-width: 400px;
   margin: 0 auto;
@@ -166,13 +171,15 @@ const S_MyPageContainer = styled.div`
   border: 1px solid #ddd;
   border-radius: 8px;
   background-color: #44484f;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   width: 400px;
 `;
+
 const S_MyPageForm = styled.div`
   display: flex;
   flex-direction: column;
 `;
+
 const S_MyPageInput = styled.input`
   margin-bottom: 10px;
   padding: 10px;
@@ -185,6 +192,7 @@ const S_MyPageInput = styled.input`
     border-color: #40a9ff;
   }
 `;
+
 const S_MyPageButton = styled.button`
   padding: 10px;
   border: none;
@@ -195,17 +203,20 @@ const S_MyPageButton = styled.button`
   font-size: 16px;
   cursor: pointer;
 `;
+
 const S_ProfileItem = styled.div`
   padding: 10px;
   color: white;
   font-size: 16px;
 `;
+
 const S_ProfileImage = styled.img`
   max-width: 100%;
   height: auto;
   border-radius: 4px;
   margin-top: 10px;
 `;
+
 const S_ProfileTitle = styled.strong`
   font-weight: bold;
   color: #36d0d2;


### PR DESCRIPTION
## What is this PR? 🔍
- supabase에 url(Strin)이 아닌 File 데이터를 전송하지 않도록 수정
- 변경된 유저 데이터를 다시 fetch하지 않아도 바로 반영할 수 있도록 state 사용하여 수정 후 변경된 프로필 바로 보이도록 변경

## Screenshot 📸
![프로필사진 등록 후 바로 반영, 삭제](https://github.com/user-attachments/assets/403802ae-1a41-4d70-bd42-49d7d05cfc0c)

## Test Checklist ☑️
- [x] 프로필 사진, 닉네임 변경 후 수정 완료 눌렀을 때 MyPage에서 바로 확인할 수 있는지 확인
- [x] 프로필 사진 변경 시 supabase에 url이 저장되는지 확인
- [x] 프로필 사진 삭제 적용되는 것 확인                            
